### PR TITLE
Dependency updates for PyInstaller

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,8 @@ numpy ~= 1.13
 
 pytest >= 3.3
 
+setuptools
+
+wheel
+
 PyInstaller ~= 3.3


### PR DESCRIPTION
Some libs need to be installed with `setuptools`.
It should be installed before PyInstaller.