### PR TITLE
Fix group box incon display on windows

### DIFF
--- a/kucher/view/main_window/register_view_widget/__init__.py
+++ b/kucher/view/main_window/register_view_widget/__init__.py
@@ -103,7 +103,7 @@ class RegisterViewWidget(WidgetBase):
         self._tree.setContextMenuPolicy(Qt.ActionsContextMenu)
 
         # Not sure about this one. This hardcoded value may look bad on some platforms.
-        self._tree.setIndentation(8)
+        self._tree.setIndentation(20)
 
         def add_action(callback: typing.Callable[[], None],
                        icon_name: str,


### PR DESCRIPTION
This icon is bigger on Windows than on Linux, so it needs more space to render correctly.