### PR TITLE
Fixed the unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,14 @@ The following command line options are available:
 
 * `--debug` - activates verbose logging; useful for troubleshooting.
 * `--profile` - creates a profile file after the application is closed.
-* `--test` - run unit tests.
-    * `-k` - can be used in conjunction with `--test` to run a specific test.
-    Refer to the PyTest documentation for more information.
-    * Other options can be provided with `--test`; they will be passed directly to
-    the PyTest framework.
+
+### Running the unit tests
+
+From the root directory:
+
+```bash
+PYTHONPATH=kucher pytest  # TODO: fix imports to make "PYTHONPATH=kucher" unnecessary
+```
 
 ### Getting the right version of Python
 

--- a/kucher/__init__.py
+++ b/kucher/__init__.py
@@ -19,8 +19,8 @@ import sys
 if sys.version_info[:2] < (3, 6):
     raise ImportError('A newer version of Python is required')
 
-from .version import *
-from .main import main
+from .version import *  # noqa
+from .main import main  # noqa
 
 #
 # Configuring the third-party modules.
@@ -36,10 +36,9 @@ THIRDPARTY_PATH = [
     os.path.join(THIRDPARTY_PATH_ROOT, 'quamash'),
 ]
 
- # 'dataclasses' module is included in Python libraries since version 3.7. For Python versions below, the dataclass
- # module located in the 'libraries' directory will be used. It is not compatible with Python 3.7, so we only declare
- # its path if Python version is below 3.7. Otherwise, the built-in module will be used by default.
- 
+# 'dataclasses' module is included in Python libraries since version 3.7. For Python versions below, the dataclass
+# module located in the 'libraries' directory will be used. It is not compatible with Python 3.7, so we only declare
+# its path if Python version is below 3.7. Otherwise, the built-in module will be used by default.
 if sys.version_info[:2] < (3, 7):
     THIRDPARTY_PATH.append(os.path.join(THIRDPARTY_PATH_ROOT, 'dataclasses'))
 

--- a/kucher/main.py
+++ b/kucher/main.py
@@ -43,7 +43,7 @@ def main() -> int:
     import datetime
     from PyQt5.QtWidgets import QApplication
     from quamash import QEventLoop
-    from . import THIRDPARTY_PATH_ROOT, data_dir, version, resources
+    from . import data_dir, version, resources
     from .fuhrer import Fuhrer
 
     data_dir.init()
@@ -69,20 +69,6 @@ def main() -> int:
         prof = profile.Profile()
         atexit.register(save_profile)
         prof.enable()
-
-    if '--test' in sys.argv:
-        if not os.environ.get('PYTHONASYNCIODEBUG'):
-            raise RuntimeError('PYTHONASYNCIODEBUG should be set while unit testing')
-
-        import pytest
-        args = sys.argv[:]
-        args.remove('--test')
-        args.append('--ignore=' + THIRDPARTY_PATH_ROOT)
-        args.append('--capture=no')
-        args.append('--fulltrace')
-        args.append('-vv')
-        args.append('.')
-        return pytest.main(args)
 
     # Configuring the event loop
     app = QApplication(sys.argv)

--- a/kucher/resources.py
+++ b/kucher/resources.py
@@ -24,7 +24,7 @@ else:
 
 
 def get_absolute_path(*relative_path_items: str, check_existence=False) -> str:
-    out = os.path.abspath(os.path.join(PACKAGE_ROOT, *relative_path_items)).replace('\\','/')
+    out = os.path.abspath(os.path.join(PACKAGE_ROOT, *relative_path_items)).replace('\\', '/')
     if check_existence:
         if not os.path.exists(out):
             raise ValueError(f'The specified path does not exist: {out}')

--- a/requirements-dev-linux.txt
+++ b/requirements-dev-linux.txt
@@ -5,11 +5,11 @@
 # General build dependencies
 setuptools
 wheel
-pycodestyle
-mypy
 
 # Test dependencies
 pytest >= 3.3
+pycodestyle
+mypy
 
 # Packaging tools
 PyInstaller ~= 3.3

--- a/requirements-dev-windows.txt
+++ b/requirements-dev-windows.txt
@@ -5,11 +5,11 @@
 # General build dependencies
 setuptools
 wheel
-pycodestyle
-mypy
 
 # Test dependencies
 pytest >= 3.3
+pycodestyle
+mypy
 
 # Packaging tools
 PyInstaller ~= 3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,12 @@
 [tool:pytest]
-python_files=*.py
-python_classes=_UnitTest
-python_functions=_unittest
+# https://docs.pytest.org/en/latest/pythonpath.html#invoking-pytest-versus-python-m-pytest
+norecursedirs =
+    kucher/libraries
+testpaths           = kucher
+python_files        = *.py
+python_classes      = _UnitTest
+python_functions    = _unittest
+addopts             = --doctest-modules -v
 
 [mypy]
 # Python version is not specified to allow checking against different versions
@@ -32,6 +37,6 @@ ignore_missing_imports = True
 [pycodestyle]
 # E221 multiple spaces before operator
 # E241 multiple spaces after ':'
-ignore = E221, E241
+ignore          = E221, E241
 max-line-length = 120
-exclude = _public_regulated_data_types
+exclude         = kucher/libraries


### PR DESCRIPTION
The `--test` option has been removed in favor of the standard approach recommended by PyTest; now you just run `PYTHONPATH=kucher pytest`. PYTHONPATH modification should not be necessary; in order to get rid of it we need to fix imports across the codebase (will open a ticket).