### PR TITLE
Fix setoint application

### DIFF
--- a/kucher/view/main_window/telega_control_widget/control_widget/run_control_widget.py
+++ b/kucher/view/main_window/telega_control_widget/control_widget/run_control_widget.py
@@ -59,6 +59,7 @@ class RunControlWidget(SpecializedControlWidgetBase):
         self._setpoint_control.status_tip = self._setpoint_control.tool_tip
         self._setpoint_control.value_change_event.connect(self._on_setpoint_changed)
         self._setpoint_control.spinbox.setKeyboardTracking(False)
+
         self._mode_selector = QComboBox(self)
         self._mode_selector.setEditable(False)
         self._mode_selector.currentIndexChanged.connect(lambda *_: self._on_control_mode_changed())

--- a/kucher/view/main_window/telega_control_widget/control_widget/run_control_widget.py
+++ b/kucher/view/main_window/telega_control_widget/control_widget/run_control_widget.py
@@ -58,7 +58,7 @@ class RunControlWidget(SpecializedControlWidgetBase):
         self._setpoint_control.tool_tip = f'To stop the motor, press {STOP_SHORTCUT} or click the Stop button'
         self._setpoint_control.status_tip = self._setpoint_control.tool_tip
         self._setpoint_control.value_change_event.connect(self._on_setpoint_changed)
-
+        self._setpoint_control.spinbox.setKeyboardTracking(False)
         self._mode_selector = QComboBox(self)
         self._mode_selector.setEditable(False)
         self._mode_selector.currentIndexChanged.connect(lambda *_: self._on_control_mode_changed())


### PR DESCRIPTION
No need to add another button. This let you write the whole value without creating intermediate setpoints. You can apply the setpoint by pressing enter or clicking outside the box.
https://doc.qt.io/qt-5/qabstractspinbox.html#keyboardTracking-prop
Closes #23