### PR TITLE
change numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ PyQt5 == 5.12.2
 pyserial ~= 3.4
 
 # https://packages.ubuntu.com/bionic/python3-numpy
+# Last version of numpy has problems with some modules when using pyinstaller. See:
+# https://stackoverflow.com/questions/57264427/in-pyinstaller-why-wont-numpy-random-common-load-as-a-module
 numpy == 1.16.2
 
 # https://packages.ubuntu.com/bionic/python3-yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ PyQt5 == 5.12.2
 pyserial ~= 3.4
 
 # https://packages.ubuntu.com/bionic/python3-numpy
-numpy ~= 1.13
+numpy == 1.16.2
 
 # https://packages.ubuntu.com/bionic/python3-yaml
 pyyaml ~= 5.1


### PR DESCRIPTION
Same problem as here:
https://stackoverflow.com/questions/57264427/in-pyinstaller-why-wont-numpy-random-common-load-as-a-module